### PR TITLE
🏷   Tag Filtering 🪄

### DIFF
--- a/.bin/build.js
+++ b/.bin/build.js
@@ -296,7 +296,7 @@ const generate = async (changelogs, site) => {
   if (!skipIndex) {
     await Promise.all([
       processIndex(site, changelogs), // run index before the others so we get all the styles,
-      processSearch(site), // Search is the same as index but doesn't statically generate changelogs
+      processSearch(site),
     ]);
   }
   return await changelogs.map(async (changelog) => {

--- a/.bin/build.js
+++ b/.bin/build.js
@@ -216,6 +216,26 @@ const processIndex = (site, changelogs) => {
   });
 };
 
+const processSearch = (site) => {
+  return new Promise((resolve, reject) => {
+    const buf = indexTemplate({
+      site,
+      changelogs: [{
+        id: '__PLACEHOLDER_ID__',
+        title: '__PLACEHOLDER_TITLE__',
+        headline: '__PLACEHOLDER_HEADLINE__',
+        dateAt: Date.now(),
+        site_id: site.id,
+        cover_image: 'https://changelog.so',
+      }],
+      search: true,
+      url: site.url,
+    });
+    const fn = path.join(distDir, "search.html");
+    minifyAndWriteHTML(fn, buf).then(resolve).catch(reject);
+  });
+};
+
 const pageTemplate = onlyEmail
   ? undefined
   : createTemplate([srcDir, webSrcDir, baseThemeDir], "page.html");
@@ -270,7 +290,10 @@ const url = `https://${host}/changelog/list/${site}/${field}?html=true&stats=tru
 
 const generate = async (changelogs, site) => {
   if (!skipIndex) {
-    await processIndex(site, changelogs); // run index before the others so we get all the styles
+    await Promise.all([
+      processIndex(site, changelogs), // run index before the others so we get all the styles,
+      processSearch(site), // Search is the same as index but doesn't statically generate changelogs
+    ]);
   }
   return await changelogs.map(async (changelog) => {
     debugLog(`processing changelog ${changelog.id} ${changelog.title}`);
@@ -338,6 +361,15 @@ const regenerateEmails = async (changelogs, site) => {
     app.use(compression());
     app.get("/", (req, resp) => {
       fn = path.join(distDir, "index.html");
+      resp.set("Content-Type", "text/html");
+      resp.set(
+        "Cache-Control",
+        "public, max-age=0, must-revalidate, stale-if-error=0"
+      );
+      resp.send(fs.readFileSync(fn));
+    });
+    app.get("/search", (req, resp) => {
+      fn = path.join(distDir, "search.html");
       resp.set("Content-Type", "text/html");
       resp.set(
         "Cache-Control",

--- a/.bin/build.js
+++ b/.bin/build.js
@@ -183,6 +183,10 @@ const indexTemplate = onlyEmail
   ? undefined
   : createTemplate([srcDir, webSrcDir, baseThemeDir], "index.html");
 
+const searchTemplate = onlyEmail
+  ? undefined
+  : createTemplate([srcDir, webSrcDir, baseThemeDir], "search.html");
+
 const minifyAndWriteHTML = (fn, buf) => {
   return new Promise((resolve, reject) => {
     fs.writeFile(fn, buf, (err) => {
@@ -218,7 +222,7 @@ const processIndex = (site, changelogs) => {
 
 const processSearch = (site) => {
   return new Promise((resolve, reject) => {
-    const buf = indexTemplate({
+    const buf = searchTemplate({
       site,
       changelogs: [{
         id: '__PLACEHOLDER_ID__',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinpt/changelog-generator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pinpt/changelog-generator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Changelog Generator is the tool for automatically generating static sites and emails published by changelog.so",
   "scripts": {
     "build": "node ./.bin/build.js",

--- a/src/theme/default/index.html
+++ b/src/theme/default/index.html
@@ -8,22 +8,30 @@
       <div class="container">
         <div>{{include src="toolbar.hbs"}}</div>
         {{include src="header.hbs"}}
-        <main class="changelogs-{{len changelogs}}">
-          {{#if (empty changelogs)}}
-          <div class="coming-soon">
-            {{include src="comingsoon.hbs" context=.}}
-          </div>
-          {{else}}
-          <div class="latest">
-            <h1>Latest</h1>
-            {{include src="tile.hbs" context=(first changelogs)}}
-          </div>
-          <div class="recent">
-            <h1>Recent</h1>
-            {{include src="tiles.hbs" changelogs=(after changelogs 1 6)}}
-          </div>
-          {{/if}}
-        </main>
+        {{#if search}}
+            <main class="changelogs">
+              <div class="recent">
+                {{include src="tiles.hbs" changelogs=(after changelogs 0 6)}}
+              </div>
+            </main>
+        {{else}}
+          <main class="changelogs-{{len changelogs}}">
+            {{#if (empty changelogs)}}
+              <div class="coming-soon">
+                {{include src="comingsoon.hbs" context=.}}
+              </div>
+            {{else}}
+              <div class="latest">
+                <h1>Latest</h1>
+                {{include src="tile.hbs" context=(first changelogs)}}
+              </div>
+              <div class="recent">
+                <h1>Recent</h1>
+                {{include src="tiles.hbs" changelogs=(after changelogs 1 6)}}
+              </div>
+            {{/if}}
+          </main>
+        {{/if}}
       </div>
       {{include src="footer.hbs"}}
     </div>

--- a/src/theme/default/index.html
+++ b/src/theme/default/index.html
@@ -9,6 +9,7 @@
         <div>{{include src="toolbar.hbs"}}</div>
         {{include src="header.hbs"}}
         {{#if search}}
+            {{include src="loader.hbs"}}
             <div class="filters">
               <h1>Filters</h1>
               <div class="taglist"></div>

--- a/src/theme/default/index.html
+++ b/src/theme/default/index.html
@@ -15,7 +15,7 @@
               <div class="taglist"></div>
             </div>
             <main class="changelogs">
-              <div class="recent">
+              <div class="recent results">
                 {{include src="tiles.hbs" changelogs=(after changelogs 0 6)}}
               </div>
             </main>

--- a/src/theme/default/index.html
+++ b/src/theme/default/index.html
@@ -8,35 +8,22 @@
       <div class="container">
         <div>{{include src="toolbar.hbs"}}</div>
         {{include src="header.hbs"}}
-        {{#if search}}
-            {{include src="loader.hbs"}}
-            <div class="filters">
-              <h1>Filters</h1>
-              <div class="taglist"></div>
+        <main class="changelogs-{{len changelogs}}">
+          {{#if (empty changelogs)}}
+            <div class="coming-soon">
+              {{include src="comingsoon.hbs" context=.}}
             </div>
-            <main class="changelogs">
-              <div class="recent results">
-                {{include src="tiles.hbs" changelogs=(after changelogs 0 6)}}
-              </div>
-            </main>
-        {{else}}
-          <main class="changelogs-{{len changelogs}}">
-            {{#if (empty changelogs)}}
-              <div class="coming-soon">
-                {{include src="comingsoon.hbs" context=.}}
-              </div>
-            {{else}}
-              <div class="latest">
-                <h1>Latest</h1>
-                {{include src="tile.hbs" context=(first changelogs)}}
-              </div>
-              <div class="recent">
-                <h1>Recent</h1>
-                {{include src="tiles.hbs" changelogs=(after changelogs 1 6)}}
-              </div>
-            {{/if}}
-          </main>
-        {{/if}}
+          {{else}}
+            <div class="latest">
+              <h1>Latest</h1>
+              {{include src="tile.hbs" context=(first changelogs)}}
+            </div>
+            <div class="recent">
+              <h1>Recent</h1>
+              {{include src="tiles.hbs" changelogs=(after changelogs 1 6)}}
+            </div>
+          {{/if}}
+        </main>
       </div>
       {{include src="footer.hbs"}}
     </div>

--- a/src/theme/default/index.html
+++ b/src/theme/default/index.html
@@ -9,6 +9,10 @@
         <div>{{include src="toolbar.hbs"}}</div>
         {{include src="header.hbs"}}
         {{#if search}}
+            <div class="filters">
+              <h1>Filters</h1>
+              <div class="taglist"></div>
+            </div>
             <main class="changelogs">
               <div class="recent">
                 {{include src="tiles.hbs" changelogs=(after changelogs 0 6)}}

--- a/src/theme/default/search.html
+++ b/src/theme/default/search.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	{{include src="head.hbs"}}
+</head>
+
+<body>
+	<div class="home">
+		<div class="container">
+			<div>{{include src="toolbar.hbs"}}</div>
+			{{include src="header.hbs"}}
+			{{include src="loader.hbs"}}
+			<div class="filters">
+				<h1>Filters</h1>
+				<div class="taglist"></div>
+			</div>
+			<main class="changelogs">
+				<div class="recent results">
+					{{include src="tiles.hbs" changelogs=(after changelogs 0 6)}}
+				</div>
+			</main>
+		</div>
+		{{include src="footer.hbs"}}
+	</div>
+</body>
+
+</html>

--- a/src/theme/default/theme.css
+++ b/src/theme/default/theme.css
@@ -154,8 +154,13 @@ footer .legal .powered-by a {
   @apply mx-auto mt-14 mb-14 flex flex-col md:flex-row;
 }
 
+.home .filters {
+  @apply mx-auto mt-14 mb-14 flex flex-col md:flex-row items-center;
+}
+
 .home main .latest > h1,
-.home main .recent > h1 {
+.home main .recent > h1,
+.home .filters > h1 {
   @apply flex-shrink-0 mb-10 md:mb-0 w-auto md:w-1/4 mr-0 md:mr-4 text-2xl font-semibold text-gray-700 dark:text-white;
 }
 
@@ -321,6 +326,14 @@ main .highfive .counter-animation.animating {
 
 .taglist {
   @apply mt-6 sm:mt-10 gap-x-2 gap-y-1 flex justify-start flex-grow-0 flex-wrap text-xs space-x-2 font-semibold;
+}
+
+.filters > .taglist {
+  @apply m-0;
+}
+
+.tag.clickable {
+  @apply cursor-pointer;
 }
 
 section.bottom {

--- a/src/theme/default/theme.css
+++ b/src/theme/default/theme.css
@@ -424,3 +424,11 @@ main .changelog > section p > a[href]:not(.mark-color) {
 .loader .inner {
   @apply w-12 h-12 dark:border-white border-[#111827] border-3 rounded-full animate-ping;
 }
+
+.empty-search {
+  @apply text-center w-full dark:text-white text-[#111827];
+}
+
+.clear-button {
+  @apply mt-6 text-sm cursor-pointer text-purple-500 dark:text-purple-500 hover:text-purple-700 dark:hover:text-purple-400;
+}

--- a/src/theme/default/theme.css
+++ b/src/theme/default/theme.css
@@ -416,3 +416,11 @@ main .changelog > section p > a[href]:not(.mark-color) {
 .coming-soon .image {
   @apply my-20 w-full;
 }
+
+.loader {
+  @apply absolute left-0 top-0 right-0 bottom-0 bg-white dark:bg-[#111827] flex items-center justify-center dark:text-white text-[#111827];
+}
+
+.loader .inner {
+  @apply w-12 h-12 dark:border-white border-[#111827] border-3 rounded-full animate-ping;
+}

--- a/src/web/global.js
+++ b/src/web/global.js
@@ -385,6 +385,7 @@ function createTag(tag, background, color, border, remove) {
 
       function handleHits (res) {
         if (res && res.hits && res.hits.length) {
+          document.querySelector('.loader').remove();
           res.hits.forEach((hit) => grid.appendChild(getTileElement(hit, template)));
         }
       }

--- a/src/web/global.js
+++ b/src/web/global.js
@@ -126,6 +126,27 @@ function createTag(tag, background, color, border, remove) {
   return element;
 }
 
+function createSearchEmptyState() {
+  const element = document.createElement('div');
+  const container = document.createElement('p');
+  const clearFilters = document.createElement('div');
+
+  clearFilters.innerHTML = '×&nbsp;&nbsp;Remove Filters'
+  clearFilters.onclick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    exitFiltering();
+    return false;
+  };
+  clearFilters.classList = 'clear-button';
+  container.innerText = 'No results matched your filters';
+  element.appendChild(container);
+  element.appendChild(clearFilters);
+  element.classList = 'empty-search';
+
+  return element;
+}
+
 (function () {
   // wire up tiles
   const tiles = document.querySelectorAll(".tile");
@@ -382,11 +403,16 @@ function createTag(tag, background, color, border, remove) {
       const template = container.cloneNode(true);
       grid.innerHTML = "";
       filters.forEach(renderRemoveFilterButton);
-
       function handleHits (res) {
-        if (res && res.hits && res.hits.length) {
+        if (res) {
           document.querySelector('.loader').remove();
-          res.hits.forEach((hit) => grid.appendChild(getTileElement(hit, template)));
+          if (res.hits && res.hits.length) {
+            res.hits.forEach((hit) => grid.appendChild(getTileElement(hit, template)));
+          } else {
+            document.querySelector('.tiles').remove();
+            const element = createSearchEmptyState();
+            document.querySelector('.results').appendChild(element);
+          }
         }
       }
 

--- a/src/web/head.hbs
+++ b/src/web/head.hbs
@@ -23,5 +23,9 @@
   async
   defer
 ></script>
-<script src="https://cdn.jsdelivr.net/npm/algoliasearch@4.5.1/dist/algoliasearch-lite.umd.js"></script>
+<script
+  src="https://cdn.jsdelivr.net/npm/algoliasearch@4.5.1/dist/algoliasearch-lite.umd.js"
+  async
+  defer
+></script>
 {{script "/global.js"}}

--- a/src/web/head.hbs
+++ b/src/web/head.hbs
@@ -23,4 +23,5 @@
   async
   defer
 ></script>
+<script src="https://cdn.jsdelivr.net/npm/algoliasearch@4.5.1/dist/algoliasearch-lite.umd.js"></script>
 {{script "/global.js"}}

--- a/src/web/loader.hbs
+++ b/src/web/loader.hbs
@@ -1,0 +1,3 @@
+<div class="loader">
+	<div class="inner"></div>
+</div>

--- a/src/web/taglist.hbs
+++ b/src/web/taglist.hbs
@@ -1,8 +1,9 @@
 <div class="taglist">
   {{#each changelog.tagColors}}
     <span
-      class="tag {{tag}}"
+      class="tag clickable {{tag}}"
       style="background-color:{{backgroundColor}};color:{{color}};border:{{border}}"
+	  data-tag="{{tag}}"
     >
       {{tag}}
     </span>

--- a/src/web/taglist.hbs
+++ b/src/web/taglist.hbs
@@ -3,7 +3,10 @@
     <span
       class="tag clickable {{tag}}"
       style="background-color:{{backgroundColor}};color:{{color}};border:{{border}}"
-	  data-tag="{{tag}}"
+	    data-tag="{{tag}}"
+      data-color="{{color}}"
+      data-background="{{backgroundColor}}"
+      data-border="{{border}}"
     >
       {{tag}}
     </span>

--- a/src/web/tile.hbs
+++ b/src/web/tile.hbs
@@ -9,7 +9,7 @@
     <div class="empty">&nbsp;</div>
   {{/if}}
   <div class="container">
-    <h2>{{title}}</h2>
+    <h2 class="title">{{title}}</h2>
     <p class="date">{{friendly-date dateAt}}</p>
     {{include src="taglist.hbs" changelog=.}}
     <p class="headline">{{headline}}</p>


### PR DESCRIPTION
Adds the ability to filter changelogs by clicking on tags!

Clicking a tag will take users to a special dynamic page to render the search results. Tags can be compounded together by clicking on additional tags after filtering. 

![Screen Shot 2021-06-29 at 2 50 03 PM](https://user-images.githubusercontent.com/12700819/123858599-529e0780-d8e9-11eb-95c2-559159c91640.png)
